### PR TITLE
[Fix] 매칭되는 키워드 없을 시 division by zero 에러

### DIFF
--- a/extract_keyword.py
+++ b/extract_keyword.py
@@ -70,6 +70,9 @@ def get_keyword(application):
 
     ## 전체 합계
     total = p_cnt + c_cnt + ch_cnt + ps_cnt + l_cnt + it_cnt
+    
+    if total == 0:
+        return top_5, [0, 0, 0, 0, 0, 0]
 
     ## 수치 계산
     p_val = round(p_cnt / total * 100, 2)


### PR DESCRIPTION
지원서 답변과 단어사전에서 매칭되는 키워드 없을 시 division by zero 에러를 해결하였습니다.